### PR TITLE
Build fix: need to add -lpi_rpc to build ovs-vswitchd

### DIFF
--- a/vswitchd/automake.mk
+++ b/vswitchd/automake.mk
@@ -15,7 +15,8 @@ vswitchd_ovs_vswitchd_LDADD = \
 	ofproto/libofproto.la \
 	p4rt/libp4rt.la \
 	lib/libsflow.la \
-	lib/libopenvswitch.la
+	lib/libopenvswitch.la \
+        -lpi_rpc
 vswitchd_ovs_vswitchd_LDFLAGS = $(AM_LDFLAGS) $(DPDK_vswitchd_LDFLAGS)
 MAN_ROOTS += vswitchd/ovs-vswitchd.8.in
 


### PR DESCRIPTION
P4-OvS fails to build, due to missing inclusion of the pi_rpc library, as reported in https://github.com/osinstom/P4-OvS/issues/4 ,
leading to undefined symbols:
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_node_modify'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_grp_create'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_activate_mbr'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_update_device_end'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_session_init'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_entry_modify_wkey'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_counter_read'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_create'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_meter_read_direct'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_destroy'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_learn_config_set'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_remove_mbr'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_add_mbr'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_mbr_modify'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_grp_delete'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_deactivate_mbr'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_fetch'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_meter_set'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_session_init'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_port_status_get'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_init'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_counter_write_direct'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_entries_fetch_one'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_mbr_fetch'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_remove_device'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_entries_fetch_done'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_batch_end'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_learn_msg_done'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_session_cleanup'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_batch_begin'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_counter_write'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_entries_fetch_wkey'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_counter_read_direct'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_learn_msg_ack'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_node_delete'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_meter_read'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_entries_fetch'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_entry_modify'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_mbr_delete'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_api_support'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_node_create'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_meter_set_direct'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_session_cleanup'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_entry_get_remaining_ttl'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_clone_session_reset'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_grp_detach_node'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_delete'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_packetout_send'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_grp_set_mbrs'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_clone_session_set'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_counter_hw_sync'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_act_prof_mbr_create'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_mc_grp_attach_node'
/usr/bin/ld: /usr/lib/libpi.so: undefined reference to `_pi_table_idle_timeout_config_set'

This pull request adds the missing pi_rpc library to the automake.mk to fix the build issue.